### PR TITLE
Add python 3.9 builds (#446)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,9 +1,6 @@
 # TODO: update this from inside the build to use branch current version
 version: '{build}'
 
-image:
-- Visual Studio 2015
-
 #cache:
 #- 'C:\Python38\'
 #- 'C:\Python38-x64'
@@ -13,17 +10,32 @@ environment:
   libyaml_refspec: 0.2.2
   PYYAML_TEST_GROUP: all
 
-#  matrix:
-#    - PYTHON_VER: Python27
-#    - PYTHON_VER: Python27-x64
-#    - PYTHON_VER: Python35
-#    - PYTHON_VER: Python35-x64
-#    - PYTHON_VER: Python36
-#    - PYTHON_VER: Python36-x64
-#    - PYTHON_VER: Python37
-#    - PYTHON_VER: Python37-x64
-#    - PYTHON_VER: Python38
-#    - PYTHON_VER: Python38-x64
+
+  matrix:
+    - PYTHON_VER: Python27
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python27-x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python35
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python35-x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python36
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python36-x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python37
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python37-x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python38
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python38-x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python39
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    - PYTHON_VER: Python39-x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
 
 #init:
 #- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))


### PR DESCRIPTION
Have to use Visual Studio 2019 for 3.9, leave the rest using Visual
Studio 2015 still.