### PR TITLE
Add python 3.9 builds (#446)

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,9 +1,6 @@
 # TODO: update this from inside the build to use branch current version
 version: '{build}'
 
-image:
-- Visual Studio 2015
-
 #cache:
 #- 'C:\Python38\'
 #- 'C:\Python38-x64'
@@ -13,17 +10,32 @@ environment:
   libyaml_refspec: 0.2.2
   PYYAML_TEST_GROUP: all
 
-#  matrix:
-#    - PYTHON_VER: Python27
-#    - PYTHON_VER: Python27-x64
-#    - PYTHON_VER: Python35
-#    - PYTHON_VER: Python35-x64
-#    - PYTHON_VER: Python36
-#    - PYTHON_VER: Python36-x64
-#    - PYTHON_VER: Python37
-#    - PYTHON_VER: Python37-x64
-#    - PYTHON_VER: Python38
-#    - PYTHON_VER: Python38-x64
+
+  matrix:
+    - PYTHON_VER: Python27
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python27-x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python35
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python35-x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python36
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python36-x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python37
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python37-x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python38
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python38-x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+    - PYTHON_VER: Python39
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    - PYTHON_VER: Python39-x64
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
 
 #init:
 #- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))

--- a/packaging/build/appveyor.ps1
+++ b/packaging/build/appveyor.ps1
@@ -14,16 +14,6 @@ Function Invoke-Exe([scriptblock]$sb) {
 }
 
 Function Bootstrap() {
-<#
-    # ensure python 3.9 prerelease is present (current Appveyor VS2015 image doesn't include it)
-    If(-not $(Test-Path C:\Python39)) {
-        Invoke-Exe { choco.exe install python3 --version=3.9.0-a1 --forcex86 --force --params="/InstallDir:C:\Python39" --no-progress }
-    }
-
-    If(-not $(Test-Path C:\Python39-x64)) {
-        Invoke-Exe { choco.exe install python3 --version=3.9.0-a1 --force --params="/InstallDir:C:\Python39-x64" --no-progress }
-    }
-#>
     Write-Output "patching Windows SDK bits for distutils"
 
     # patch 7.0/7.1 vcvars SDK bits up to work with distutils query
@@ -49,9 +39,9 @@ Function Bootstrap() {
     }
 }
 
-Function Build-Wheel($python_path) {
+Function Build-Wheel() {
 
-    #$python_path = Join-Path C:\ $env:PYTHON_VER
+    $python_path = Join-Path C:\ $env:PYTHON_VER
     $python = Join-Path $python_path python.exe
 
     Write-Output "building pyyaml wheel for $python_path"
@@ -115,24 +105,5 @@ Function Upload-Artifacts() {
 }
 
 Bootstrap
-
-$pythons = @(
-"C:\Python27"
-"C:\Python27-x64"
-"C:\Python35"
-"C:\Python35-x64"
-"C:\Python36"
-"C:\Python36-x64"
-"C:\Python37"
-"C:\Python37-x64"
-"C:\Python38"
-"C:\Python38-x64"
-)
-
-#$pythons = @("C:\$($env:PYTHON_VER)")
-
-foreach($python in $pythons) {
-    Build-Wheel $python
-}
-
+Build-Wheel
 Upload-Artifacts


### PR DESCRIPTION
Have to use Visual Studio 2019 for 3.9, leave the rest using Visual
Studio 2015 still.